### PR TITLE
fix: allow user to set multiple config vars on sf login

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,7 +6,7 @@
  */
 
 import { prompt, Answers } from 'inquirer';
-import { AuthFields, Messages } from '@salesforce/core';
+import { AuthFields, Messages, OrgConfigProperties } from '@salesforce/core';
 import { SfCommand } from '@salesforce/sf-plugins-core';
 import { executeOrgWebFlow, handleSideEffects, OrgSideEffects } from '../loginUtils';
 
@@ -83,18 +83,23 @@ export default class Login extends SfCommand<AuthFields> {
   }
 
   private async promptUserForOrgSideEffects(): Promise<OrgSideEffects> {
-    const responses = await prompt<OrgSideEffects>([
+    const responses = await prompt<{ alias: string; configs: string[] }>([
       {
         name: 'alias',
         message: 'Set an alias for the org (leave blank for no alias)',
         type: 'input',
       },
       {
-        name: 'setDefault',
+        name: 'configs',
         message: 'Set the org as your default org?',
-        type: 'confirm',
+        type: 'checkbox',
+        choices: [OrgConfigProperties.TARGET_DEV_HUB, OrgConfigProperties.TARGET_ORG],
       },
     ]);
-    return responses;
+    return {
+      alias: responses.alias,
+      setDefault: responses.configs.includes(OrgConfigProperties.TARGET_ORG),
+      setDefaultDevHub: responses.configs.includes(OrgConfigProperties.TARGET_DEV_HUB),
+    };
   }
 }


### PR DESCRIPTION
### What does this PR do?

Allows user to select `target-dev-hub` and/or `target-org` when running `sf login`

![Screen Shot 2021-09-21 at 10 43 29 AM](https://user-images.githubusercontent.com/10244328/134213293-c5a57bcd-c865-4c57-9368-16a4c65370b6.png)

![Screen Shot 2021-09-21 at 10 50 40 AM](https://user-images.githubusercontent.com/10244328/134213540-46bf140b-6f5d-4742-ba48-e6e3469ed32c.png)

### What issues does this PR fix or reference?
@W-9927903@