### PR TITLE
Remove mention of orgs from the messages of interactive commands

### DIFF
--- a/messages/login.md
+++ b/messages/login.md
@@ -1,14 +1,10 @@
 # summary
 
-Log interactively into an environment, such as a Salesforce org.
+Log interactively into an environment.
 
 # description
 
-Logging into an environment authorizes the CLI to run other commands that connect to that environment, such as deploying or retrieving metadata to and from an org.
-
-The command first prompts you to choose an environment from a list of available ones. It then opens a browser to the appropriate login URL, such as https://login.salesforce.com for an org. Then, depending on the environment you choose, the command prompts for other actions, such as giving the environment an alias or setting it as your default.
-
-This command is fully interactive and has no flags other than displaying the command-line help. Each environment has its own specific login command, such as "sf login org", which usually provide more flags than this interactive one. For more information about the interactive prompts from this command, see the help for the environment-specific command, such as "sf login org --help".
+Logging into an environment authorizes the CLI to run other commands that connect to that environment.
 
 # examples
 

--- a/messages/logout.md
+++ b/messages/logout.md
@@ -1,12 +1,10 @@
 # summary
 
-Log out interactively from environments, such as Salesforce orgs and compute environments.
+Log out interactively from environments.
 
 # description
 
 By default, the command prompts you to select which environments you want to log out of. Use --no-prompt to not be prompted and log out of all environments.
-
-Be careful! If you log out of a scratch org without having access to its password, you can't access the scratch org again, either through the CLI or the Salesforce UI.
 
 # examples
 


### PR DESCRIPTION
### What does this PR do?

the interactive "sf login|logout" commands will no longer work against orgs, so this PR removes any mention of orgs from the --help

### What issues does this PR fix or reference?

@W-12460657@
