### PR TITLE
fix: add deprecated note to command description so it shows up in Ref Guide

### DIFF
--- a/messages/login.md
+++ b/messages/login.md
@@ -4,6 +4,8 @@ Log interactively into an environment.
 
 # description
 
+NOTE: This general command is deprecated. Use specific commands instead, such as "org login web" or "org login jwt".
+
 Logging into an environment authorizes the CLI to run other commands that connect to that environment.
 
 # examples

--- a/messages/logout.md
+++ b/messages/logout.md
@@ -4,6 +4,8 @@ Log out interactively from environments.
 
 # description
 
+NOTE: This general command is deprecated. Use specific commands instead, such as "org login web" or "org login jwt".
+
 By default, the command prompts you to select which environments you want to log out of. Use --no-prompt to not be prompted and log out of all environments.
 
 # examples


### PR DESCRIPTION
### What does this PR do?

Adds a deprecation note to the command description with the commands the customer should use instead.

NOTE:  For some reason, the [Ref Guide page](https://developer.salesforce.com/docs/atlas.en-us.sfdx_cli_reference.meta/sfdx_cli_reference/cli_reference_login_commands_unified.htm#cli_reference_login_unified) for this command doesn't print the same deprecation message that shows up in the `--help` output.  Rather than try to fix the command generator, I'm taking the easy route and adding a duplicate note to the command description.  Not ideal, I know, but at some point we won't use the command generator anymore, so it's not worth the time to fix it for this one-off issue. 

### What issues does this PR fix or reference?

@W-14191916@
